### PR TITLE
Add pauseAudio() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ cordova plugin add cordova-plugin-streaming-media
   };
   window.plugins.streamingMedia.playAudio(audioUrl, options);
 
+  // Pause current audio
+  window.plugins.streamingMedia.pauseAudio();
 
   // Stop current audio
   window.plugins.streamingMedia.stopAudio();

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ cordova plugin add cordova-plugin-streaming-media
   // Pause current audio
   window.plugins.streamingMedia.pauseAudio();
 
+  // Resume current audio
+  window.plugins.streamingMedia.resumeAudio();
+
   // Stop current audio
   window.plugins.streamingMedia.stopAudio();
 

--- a/src/ios/StreamingMedia.m
+++ b/src/ios/StreamingMedia.m
@@ -73,6 +73,13 @@ NSString * const DEFAULT_IMAGE_SCALE = @"center";
 	[self startPlayer:mediaUrl];
 }
 
+-(void)pause:(CDVInvokedUrlCommand *) command type:(NSString *) type {
+    callbackId = command.callbackId;
+    if (moviePlayer) {
+        [moviePlayer pause];
+    }
+}
+
 -(void)stop:(CDVInvokedUrlCommand *) command type:(NSString *) type {
     callbackId = command.callbackId;
     if (moviePlayer) {
@@ -86,6 +93,10 @@ NSString * const DEFAULT_IMAGE_SCALE = @"center";
 
 -(void)playAudio:(CDVInvokedUrlCommand *) command {
 	[self play:command type:[NSString stringWithString:TYPE_AUDIO]];
+}
+
+-(void)pauseAudio:(CDVInvokedUrlCommand *) command {
+    [self pause:command type:[NSString stringWithString:TYPE_AUDIO]];
 }
 
 -(void)stopAudio:(CDVInvokedUrlCommand *) command {

--- a/src/ios/StreamingMedia.m
+++ b/src/ios/StreamingMedia.m
@@ -107,7 +107,7 @@ NSString * const DEFAULT_IMAGE_SCALE = @"center";
 }
 
 -(void)resumeAudio:(CDVInvokedUrlCommand *) command {
-    [self pause:command type:[NSString stringWithString:TYPE_AUDIO]];
+    [self resume:command type:[NSString stringWithString:TYPE_AUDIO]];
 }
 
 -(void)stopAudio:(CDVInvokedUrlCommand *) command {

--- a/src/ios/StreamingMedia.m
+++ b/src/ios/StreamingMedia.m
@@ -80,6 +80,13 @@ NSString * const DEFAULT_IMAGE_SCALE = @"center";
     }
 }
 
+-(void)resume:(CDVInvokedUrlCommand *) command type:(NSString *) type {
+    callbackId = command.callbackId;
+    if (moviePlayer) {
+        [moviePlayer play];
+    }
+}
+
 -(void)stop:(CDVInvokedUrlCommand *) command type:(NSString *) type {
     callbackId = command.callbackId;
     if (moviePlayer) {
@@ -96,6 +103,10 @@ NSString * const DEFAULT_IMAGE_SCALE = @"center";
 }
 
 -(void)pauseAudio:(CDVInvokedUrlCommand *) command {
+    [self pause:command type:[NSString stringWithString:TYPE_AUDIO]];
+}
+
+-(void)resumeAudio:(CDVInvokedUrlCommand *) command {
     [self pause:command type:[NSString stringWithString:TYPE_AUDIO]];
 }
 

--- a/www/StreamingMedia.js
+++ b/www/StreamingMedia.js
@@ -7,6 +7,11 @@ StreamingMedia.prototype.playAudio = function (url, options) {
 	cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "playAudio", [url, options]);
 };
 
+StreamingMedia.prototype.pauseAudio = function (options) {
+    options = options || {};
+    cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "pauseAudio", [options]);
+};
+
 StreamingMedia.prototype.stopAudio = function (options) {
     options = options || {};
     cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "stopAudio", [options]);

--- a/www/StreamingMedia.js
+++ b/www/StreamingMedia.js
@@ -12,6 +12,11 @@ StreamingMedia.prototype.pauseAudio = function (options) {
     cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "pauseAudio", [options]);
 };
 
+StreamingMedia.prototype.resumeAudio = function (options) {
+    options = options || {};
+    cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "resumeAudio", [options]);
+};
+
 StreamingMedia.prototype.stopAudio = function (options) {
     options = options || {};
     cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "stopAudio", [options]);


### PR DESCRIPTION
Adds a playAudio() method to the plugin. The stopAudio() does not
maintain the position when called, the new pauseAudio() method maintains
position and allows resuming.

**Related issues**
https://github.com/nchutchind/cordova-plugin-streaming-media/issues/59

