### PR TITLE
Ability to hide controls on fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ cordova plugin add cordova-plugin-streaming-media
     errorCallback: function(errMsg) {
       console.log("Error! " + errMsg);
     },
-    orientation: 'landscape'
+    orientation: 'landscape',
+    shouldAutoClose: true,  // true(default)/false
+    controls: true // true(default)/false. Used to hide controls on fullscreen
   };
   window.plugins.streamingMedia.playVideo(videoUrl, options);
 

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
@@ -82,7 +82,7 @@ public class SimpleVideoStream extends Activity implements
 			mMediaController = new MediaController(this);
 			mMediaController.setAnchorView(mVideoView);
 			mMediaController.setMediaPlayer(mVideoView);
-			if (!controls) {
+			if (!mControls) {
 				mMediaController.setVisibility(View.GONE);
 			}
 			mVideoView.setMediaController(mMediaController);

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
@@ -31,6 +31,7 @@ public class SimpleVideoStream extends Activity implements
 	private ProgressBar mProgressBar = null;
 	private String mVideoUrl;
 	private Boolean mShouldAutoClose = true;
+	private boolean mControls;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -42,6 +43,7 @@ public class SimpleVideoStream extends Activity implements
 		mVideoUrl = b.getString("mediaUrl");
 		mShouldAutoClose = b.getBoolean("shouldAutoClose");
 		mShouldAutoClose = mShouldAutoClose == null ? true : mShouldAutoClose;
+		mControls = b.getBoolean("controls", true);
 
 		RelativeLayout relLayout = new RelativeLayout(this);
 		relLayout.setBackgroundColor(Color.BLACK);
@@ -80,6 +82,9 @@ public class SimpleVideoStream extends Activity implements
 			mMediaController = new MediaController(this);
 			mMediaController.setAnchorView(mVideoView);
 			mMediaController.setMediaPlayer(mVideoView);
+			if (!controls) {
+				mMediaController.setVisibility(View.GONE);
+			}
 			mVideoView.setMediaController(mMediaController);
 		} catch (Throwable t) {
 			Log.d(TAG, t.toString());

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
@@ -73,7 +73,7 @@ public class StreamingMedia extends CordovaPlugin {
 								extras.putString(optKey, (String)options.get(optKey));
 								Log.v(TAG, "Added option: " + optKey + " -> " + String.valueOf(options.get(optKey)));
 							} else if (options.get(optKey).getClass().equals(Boolean.class)) {
-								extras.putBoolean("shouldAutoClose", true);
+								extras.putBoolean(optKey, (Boolean)options.get(optKey));
 								Log.v(TAG, "Added option: " + optKey + " -> " + String.valueOf(options.get(optKey)));
 							}
 

--- a/src/ios/StreamingMedia.m
+++ b/src/ios/StreamingMedia.m
@@ -19,6 +19,7 @@
 	UIColor *backgroundColor;
 	UIImageView *imageView;
     BOOL *initFullscreen;
+    BOOL controls;
 }
 
 NSString * const TYPE_VIDEO = @"VIDEO";
@@ -43,6 +44,12 @@ NSString * const DEFAULT_IMAGE_SCALE = @"center";
     } else {
         initFullscreen = true;
     }
+
+    if (![options isKindOfClass:[NSNull class]] && [options objectForKey:@"controls"]) {
+            controls = [[options objectForKey:@"controls"] boolValue];
+        } else {
+            controls = true;
+        }
 
 	if ([type isEqualToString:TYPE_AUDIO]) {
 		// bgImage
@@ -211,7 +218,11 @@ NSString * const DEFAULT_IMAGE_SCALE = @"center";
 												 name:UIDeviceOrientationDidChangeNotification
 											   object:nil];
 
-	moviePlayer.controlStyle = MPMovieControlStyleDefault;
+	if (controls) {
+        [moviePlayer setControlStyle:MPMovieControlStyleDefault];
+    } else {
+        [moviePlayer setControlStyle:MPMovieControlStyleNone];
+    }
 
 	moviePlayer.shouldAutoplay = YES;
 	if (imageView != nil) {


### PR DESCRIPTION
**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**

It is an enhancement to give user an ability to hide controls on full screen while video is playing.

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**
This enhancement is tested on IOS 10.3.1 and Android 5.1.1 with Cordova 6.5.0.
Set the controls option to false and it will hide the controls from fullscreen. Sample is also added in Readme.md
