### PR TITLE
potrait-landscape-potrait fix for android8.1

### DIFF
--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
@@ -141,6 +141,9 @@ public class SimpleVideoStream extends Activity implements
 	}
 
 	private void wrapItUp(int resultCode, String message) {
+		if (android.os.Build.VERSION.SDK_INT >= 27) {
+            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR);
+        }
 		Intent intent = new Intent();
 		intent.putExtra("message", message);
 		setResult(resultCode, intent);


### PR DESCRIPTION
<!--
Note that leaving sections blank will make it difficult for us understand what this PR is for and it may be closed.
-->

**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**

Was having issue while exiting video on my android 8.1, haven't tested on other devices though.

Steps to reproduce
1. on android 8.1, play a video in landscape mode while app is in portrait mode
2. video plays in landscape mode , press back 
after exiting video app is in portrait mode, then goes to landscape mode and again in portrait mode.

<!-- 
Provide a general description of the code changes in your pull
request. If bugs were fixed, please document the changes and why
they were introduced.

Please ensure that your PR contains test cases that cover all new
code and any changes to existing code. Without tests, your PR is
likely to be closed without merging.
-->

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**

**Related issues**
<!--
Please review the (https://github.com/nchutchind/Streaming-Media-Cordova-Plugin/issues)
page, and link any issues that are addressed or related to this PR.
-->

https://stackoverflow.com/questions/47228194/android-8-1-screen-orientation-issue-flipping-to-landscape-a-portrait-screen

found workaround in below url
https://issuetracker.google.com/issues/69168442