### PR TITLE
iOS allows background audio & Android audio can autoclose

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,6 +36,12 @@
 				<param name="ios-package" value="StreamingMedia" />
 			</feature>
 		</config-file>
+		<config-file target="*-Info.plist" parent="UIBackgroundModes">
+			<array>
+				<string>audio</string>
+				<string>fetch</string>
+			</array>
+		</config-file>
 		<header-file src="src/ios/StreamingMedia.h" />
 		<source-file src="src/ios/StreamingMedia.m" />
 		<header-file src="src/ios/LandscapeVideo.h" />

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleAudioStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleAudioStream.java
@@ -16,7 +16,6 @@ import android.view.Window;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.MediaController;
-import android.os.PowerManager;
 
 public class SimpleAudioStream extends Activity implements
 MediaPlayer.OnCompletionListener, MediaPlayer.OnPreparedListener,
@@ -40,8 +39,7 @@ MediaController.MediaPlayerControl {
 		String backgroundColor = b.getString("bgColor");
 		String backgroundImagePath = b.getString("bgImage");
 		String backgroundImageScale = b.getString("bgImageScale");
-		mShouldAutoClose = b.getBoolean("shouldAutoClose");
-		mShouldAutoClose = mShouldAutoClose == null ? true : mShouldAutoClose;
+		mShouldAutoClose = b.getBoolean("shouldAutoClose", true);
 		backgroundImageScale = backgroundImageScale == null ? "center" : backgroundImageScale.toLowerCase();
 		ImageView.ScaleType bgImageScaleType;
 		// Default background to black


### PR DESCRIPTION
**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**

1.  Allows background audio in iOS while app is minimized, in another app, or screenlocked.
2.  Fixed autoclose parameter on Android audio.

Misc. Cleaned up an unneeded import.

**Related issues**
#126 #134 #125 #82 #35 
