### PR TITLE
iOS video black after playing audio

### DIFF
--- a/src/ios/StreamingMedia.m
+++ b/src/ios/StreamingMedia.m
@@ -72,7 +72,7 @@ NSString * const DEFAULT_IMAGE_SCALE = @"center";
             backgroundColor = [UIColor blackColor];
         }
     } else {
-        // Fix overlay on video after playing audio
+        // Reset overlay on video player after playing audio
         [self cleanup];
     }
     // No specific options for video yet

--- a/src/ios/StreamingMedia.m
+++ b/src/ios/StreamingMedia.m
@@ -71,6 +71,9 @@ NSString * const DEFAULT_IMAGE_SCALE = @"center";
         } else {
             backgroundColor = [UIColor blackColor];
         }
+    } else {
+        // Fix overlay on video after playing audio
+        [self cleanup];
     }
     // No specific options for video yet
 }


### PR DESCRIPTION
<!--
Note that leaving sections blank will make it difficult for us understand what this PR is for and it may be closed.
-->

**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**
Fixes the bug where video is blank after playing audio(because of overlay from audio player).

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**
Yup! Tested every setting, works just fine with audio & video.

**Related issues**
#141 : iOS: Video appears as black, can hear audio
<!--
Please review the (https://github.com/nchutchind/Streaming-Media-Cordova-Plugin/issues)
page, and link any issues that are addressed or related to this PR.
-->