### PR TITLE
Add onWindowFocusChanged

### DIFF
--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
@@ -204,4 +204,21 @@ MediaPlayer.OnErrorListener, MediaPlayer.OnBufferingUpdateListener {
 			mMediaController.show();
 		return false;
 	}
+	
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus) {
+            this.getWindow().getDecorView().setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+                    View.SYSTEM_UI_FLAG_FULLSCREEN |
+                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+        } else {
+            this.getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_FULLSCREEN);
+        }
+    }
 }


### PR DESCRIPTION
@shamilovtim : The test was done on 10 different devices, 8 of this has this problem.

The problem in question is that when a video starts, the navigation bar remains.
Esa cuts a part of the video in question.
With this change it allows you to see only when the video player controls appear.

Normal checks will be seen when clicking on the video.

As currently, current version:
![](https://i.imgur.com/CvLgYMo.jpg)

With the addition of the onWindowFocusChanged as set:
![](https://i.imgur.com/v8NKzG1.jpg)
