### PR TITLE
(Android) HTTP headers/authorization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ cordova plugin add https://github.com/nchutchind/cordova-plugin-streaming-media
     },
     orientation: 'landscape',
     shouldAutoClose: true,  // true(default)/false
-    controls: true // true(default)/false. Used to hide controls on fullscreen
+    controls: true, // true(default)/false. Used to hide controls on fullscreen
+    headers: {
+      Authorization: `Basic ${btoa(username + ':' + password)}`
+    }
   };
   window.plugins.streamingMedia.playVideo(videoUrl, options);
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -69,6 +69,7 @@
 		<source-file src="src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java" target-dir="src/com/hutchind/cordova/plugins/streamingmedia" />
 		<source-file src="src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java" target-dir="src/com/hutchind/cordova/plugins/streamingmedia" />
 		<source-file src="src/android/com/hutchind/cordova/plugins/streamingmedia/ImageLoadTask.java" target-dir="src/com/hutchind/cordova/plugins/streamingmedia" />
+		<source-file src="src/android/com/hutchind/cordova/plugins/streamingmedia/EventfulVideoView.java" target-dir="src/com/hutchind/cordova/plugins/streamingmedia" />
 	</platform>
 
 	<platform name="amazon-fireos">

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/EventfulVideoView.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/EventfulVideoView.java
@@ -4,10 +4,14 @@ import android.content.Context;
 import android.util.AttributeSet;
 import android.widget.VideoView;
 
+import java.util.Optional;
+
 public class EventfulVideoView extends VideoView {
 
     private PlayPauseListener playPauseListener;
     private SeekToListener seekToListener;
+
+    private Integer customDuration;
 
     public EventfulVideoView(Context context) {
         super(context);
@@ -31,6 +35,15 @@ public class EventfulVideoView extends VideoView {
 
     public void setSeekToListener(SeekToListener listener) {
         seekToListener = listener;
+    }
+
+    @Override
+    public int getDuration() {
+        return Optional.ofNullable(customDuration).orElse(super.getDuration());
+    }
+
+    public void setDuration(Integer duration) {
+        this.customDuration = duration;
     }
 
     @Override

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/EventfulVideoView.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/EventfulVideoView.java
@@ -1,0 +1,69 @@
+package com.hutchind.cordova.plugins.streamingmedia;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.VideoView;
+
+public class EventfulVideoView extends VideoView {
+
+    private PlayPauseListener playPauseListener;
+    private SeekToListener seekToListener;
+
+    public EventfulVideoView(Context context) {
+        super(context);
+    }
+
+    public EventfulVideoView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public EventfulVideoView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public EventfulVideoView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+    public void setPlayPauseListener(PlayPauseListener listener) {
+        playPauseListener = listener;
+    }
+
+    public void setSeekToListener(SeekToListener listener) {
+        seekToListener = listener;
+    }
+
+    @Override
+    public void pause() {
+        super.pause();
+        if (playPauseListener != null) {
+            playPauseListener.onStreamPause();
+        }
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        if (playPauseListener != null) {
+            playPauseListener.onStreamPlay();
+        }
+    }
+
+    @Override
+    public void seekTo(int msec) {
+        super.seekTo(msec);
+        if(seekToListener != null) {
+            seekToListener.onStreamSeekTo(msec);
+        }
+    }
+
+    public static interface PlayPauseListener {
+        void onStreamPlay();
+        void onStreamPause();
+    }
+
+    public static interface SeekToListener {
+        void onStreamSeekTo(int msec);
+    }
+
+}

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/EventfulVideoView.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/EventfulVideoView.java
@@ -12,6 +12,7 @@ public class EventfulVideoView extends VideoView {
     private SeekToListener seekToListener;
 
     private Integer customDuration;
+    private int offsetPosition;
 
     public EventfulVideoView(Context context) {
         super(context);
@@ -47,6 +48,11 @@ public class EventfulVideoView extends VideoView {
     }
 
     @Override
+    public int getCurrentPosition() {
+        return super.getCurrentPosition() - offsetPosition;
+    }
+
+    @Override
     public void pause() {
         super.pause();
         if (playPauseListener != null) {
@@ -64,7 +70,13 @@ public class EventfulVideoView extends VideoView {
 
     @Override
     public void seekTo(int msec) {
-        super.seekTo(msec);
+        if(msec < super.getDuration()) {
+            super.seekTo(msec);
+            offsetPosition = 0;
+        } else {
+            offsetPosition = super.getCurrentPosition() - msec;
+        }
+
         if(seekToListener != null) {
             seekToListener.onStreamSeekTo(msec);
         }

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleAudioStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleAudioStream.java
@@ -16,6 +16,9 @@ import android.view.Window;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.MediaController;
+import java.util.Properties;
+import java.util.Map;
+import java.io.Serializable;
 
 public class SimpleAudioStream extends Activity implements
 MediaPlayer.OnCompletionListener, MediaPlayer.OnPreparedListener,
@@ -29,6 +32,7 @@ MediaController.MediaPlayerControl {
 	private View mMediaControllerView;
 	private String mAudioUrl;
 	private Boolean mShouldAutoClose = true;
+	private Map<String, String> headers;
 
 	@Override
 	public void onCreate(Bundle icicle) {
@@ -40,6 +44,7 @@ MediaController.MediaPlayerControl {
 		String backgroundImagePath = b.getString("bgImage");
 		String backgroundImageScale = b.getString("bgImageScale");
 		mShouldAutoClose = b.getBoolean("shouldAutoClose", true);
+		headers = (Map<String,String>) b.getSerializable(StreamingMedia.INTENT_EXTRA_HEADERS);
 		backgroundImageScale = backgroundImageScale == null ? "center" : backgroundImageScale.toLowerCase();
 		ImageView.ScaleType bgImageScaleType;
 		// Default background to black
@@ -98,7 +103,7 @@ MediaController.MediaPlayerControl {
 					Log.e(TAG, e.toString());
 				}
 			}
-			mMediaPlayer.setDataSource(this, myUri); // Go to Initialized state
+			mMediaPlayer.setDataSource(this, myUri, headers); // Go to Initialized state
 			mMediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
 			mMediaPlayer.setOnPreparedListener(this);
 			mMediaPlayer.setOnCompletionListener(this);

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
@@ -30,11 +30,6 @@ MediaPlayer.OnCompletionListener, MediaPlayer.OnPreparedListener,
 MediaPlayer.OnErrorListener, MediaPlayer.OnBufferingUpdateListener,
 EventfulVideoView.PlayPauseListener, EventfulVideoView.SeekToListener {
 
-	public static final String CALLBACK_EVENT_TYPE_KEY = "eventType";
-	public static final String CALLBACK_EVENT_TYPE_VALUE_PLAY = "PLAY";
-	public static final String CALLBACK_EVENT_TYPE_VALUE_PAUSE = "PAUSE";
-	public static final String CALLBACK_EVENT_TYPE_VALUE_SEEK = "SEEK";
-
 	public static final String CALLBACK_SEEK_KEY_MSEC = "msec";
 
 	private String TAG = getClass().getSimpleName();
@@ -228,11 +223,37 @@ EventfulVideoView.PlayPauseListener, EventfulVideoView.SeekToListener {
 	}
 
 	@Override
+	protected void onPause() {
+		super.onPause();
+
+		try {
+			JSONObject callbackData = new JSONObject();
+			callbackData.put(StreamingMedia.CALLBACK_EVENT_TYPE_KEY, StreamingMedia.CALLBACK_EVENT_TYPE_VALUE_LIFECYCLE_ONPAUSE);
+			StreamingMedia.sendCallback(callbackData);
+		} catch(Exception e) {
+			Log.e(TAG, "Failed to notify of lifecycle pause event", e);
+		}
+	}
+
+	@Override
+	protected void onResume() {
+		super.onResume();
+
+		try {
+			JSONObject callbackData = new JSONObject();
+			callbackData.put(StreamingMedia.CALLBACK_EVENT_TYPE_KEY, StreamingMedia.CALLBACK_EVENT_TYPE_VALUE_LIFECYCLE_ONRESUME);
+			StreamingMedia.sendCallback(callbackData);
+		} catch(Exception e) {
+			Log.e(TAG, "Failed to notify of lifecycle resume event", e);
+		}
+	}
+
+	@Override
 	public void onStreamPlay() {
 		try {
 			JSONObject callbackData = new JSONObject();
-			callbackData.put(CALLBACK_EVENT_TYPE_KEY, CALLBACK_EVENT_TYPE_VALUE_PLAY);
-			sendCallback(callbackData);
+			callbackData.put(StreamingMedia.CALLBACK_EVENT_TYPE_KEY, StreamingMedia.CALLBACK_EVENT_TYPE_VALUE_PLAY);
+			StreamingMedia.sendCallback(callbackData);
 		} catch(Exception e) {
 			Log.e(TAG, "Failed to notify of play event", e);
 		}
@@ -242,8 +263,8 @@ EventfulVideoView.PlayPauseListener, EventfulVideoView.SeekToListener {
 	public void onStreamPause() {
 		try {
 			JSONObject callbackData = new JSONObject();
-			callbackData.put(CALLBACK_EVENT_TYPE_KEY, CALLBACK_EVENT_TYPE_VALUE_PAUSE);
-			sendCallback(callbackData);
+			callbackData.put(StreamingMedia.CALLBACK_EVENT_TYPE_KEY, StreamingMedia.CALLBACK_EVENT_TYPE_VALUE_PAUSE);
+			StreamingMedia.sendCallback(callbackData);
 		} catch(Exception e) {
 			Log.e(TAG, "Failed to notify of pause event", e);
 		}
@@ -253,17 +274,12 @@ EventfulVideoView.PlayPauseListener, EventfulVideoView.SeekToListener {
 	public void onStreamSeekTo(int msec) {
 		try {
 			JSONObject callbackData = new JSONObject();
-			callbackData.put(CALLBACK_EVENT_TYPE_KEY, CALLBACK_EVENT_TYPE_VALUE_SEEK);
+			callbackData.put(StreamingMedia.CALLBACK_EVENT_TYPE_KEY, StreamingMedia.CALLBACK_EVENT_TYPE_VALUE_SEEK);
 			callbackData.put(CALLBACK_SEEK_KEY_MSEC, msec);
-			sendCallback(callbackData);
+			StreamingMedia.sendCallback(callbackData);
 		} catch(Exception e) {
 			Log.e(TAG, "Failed to notify of seek event", e);
 		}
 	}
 
-	private void sendCallback(JSONObject callbackData) {
-		PluginResult result = new PluginResult(PluginResult.Status.OK, callbackData);
-		result.setKeepCallback(true);
-		StreamingMedia.callbackContext.sendPluginResult(result);
-	}
 }

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
@@ -1,6 +1,9 @@
 package com.hutchind.cordova.plugins.streamingmedia;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.graphics.Color;
 import android.media.MediaPlayer;
@@ -19,16 +22,14 @@ import android.widget.RelativeLayout;
 
 import java.util.Map;
 
-import org.json.JSONException;
 import org.json.JSONObject;
-
-import org.apache.cordova.PluginResult;
-import org.apache.cordova.CallbackContext;
 
 public class SimpleVideoStream extends Activity implements
 MediaPlayer.OnCompletionListener, MediaPlayer.OnPreparedListener,
 MediaPlayer.OnErrorListener, MediaPlayer.OnBufferingUpdateListener,
 EventfulVideoView.PlayPauseListener, EventfulVideoView.SeekToListener {
+
+	public static final String BROADCAST_INTENT_ACTION_STOP = "stop_video_stream";
 
 	public static final String CALLBACK_SEEK_KEY_MSEC = "msec";
 
@@ -48,6 +49,16 @@ EventfulVideoView.PlayPauseListener, EventfulVideoView.SeekToListener {
 		super.onCreate(savedInstanceState);
 		this.requestWindowFeature(Window.FEATURE_NO_TITLE);
 		this.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
+
+		BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+		@Override
+		public void onReceive(Context arg0, Intent intent) {
+			if (intent.getAction().equals(BROADCAST_INTENT_ACTION_STOP)) {
+			finish();
+			}
+		}
+		};
+		registerReceiver(broadcastReceiver, new IntentFilter(BROADCAST_INTENT_ACTION_STOP));
 
 		Bundle b = getIntent().getExtras();
 		mVideoUrl = b.getString("mediaUrl");

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
@@ -46,6 +46,7 @@ EventfulVideoView.PlayPauseListener, EventfulVideoView.SeekToListener {
 	private Boolean mShouldAutoClose = true;
 	private boolean mControls;
 	private Map<String, String> headers;
+	private Integer customDuration;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -58,6 +59,9 @@ EventfulVideoView.PlayPauseListener, EventfulVideoView.SeekToListener {
 		mShouldAutoClose = b.getBoolean("shouldAutoClose", true);
 		mControls = b.getBoolean("controls", true);
 		headers = (Map<String,String>) b.getSerializable(StreamingMedia.INTENT_EXTRA_HEADERS);
+
+		if(b.containsKey("duration"))
+			customDuration = b.getInt("duration");
 
 		RelativeLayout relLayout = new RelativeLayout(this);
 		relLayout.setBackgroundColor(Color.BLACK);
@@ -101,6 +105,7 @@ EventfulVideoView.PlayPauseListener, EventfulVideoView.SeekToListener {
 			if (!mControls) {
 				mMediaController.setVisibility(View.GONE);
 			}
+			mVideoView.setDuration(customDuration);
 			mVideoView.setMediaController(mMediaController);
 		} catch (Throwable t) {
 			Log.d(TAG, t.toString());

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/SimpleVideoStream.java
@@ -20,6 +20,9 @@ import android.widget.MediaController;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.VideoView;
+import java.util.Properties;
+import java.util.Map;
+import java.io.Serializable;
 
 public class SimpleVideoStream extends Activity implements
 MediaPlayer.OnCompletionListener, MediaPlayer.OnPreparedListener,
@@ -32,6 +35,7 @@ MediaPlayer.OnErrorListener, MediaPlayer.OnBufferingUpdateListener {
 	private String mVideoUrl;
 	private Boolean mShouldAutoClose = true;
 	private boolean mControls;
+	private Map<String, String> headers;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -43,6 +47,7 @@ MediaPlayer.OnErrorListener, MediaPlayer.OnBufferingUpdateListener {
 		mVideoUrl = b.getString("mediaUrl");
 		mShouldAutoClose = b.getBoolean("shouldAutoClose", true);
 		mControls = b.getBoolean("controls", true);
+		headers = (Map<String,String>) b.getSerializable(StreamingMedia.INTENT_EXTRA_HEADERS);
 
 		RelativeLayout relLayout = new RelativeLayout(this);
 		relLayout.setBackgroundColor(Color.BLACK);
@@ -77,7 +82,7 @@ MediaPlayer.OnErrorListener, MediaPlayer.OnBufferingUpdateListener {
 			mVideoView.setOnCompletionListener(this);
 			mVideoView.setOnPreparedListener(this);
 			mVideoView.setOnErrorListener(this);
-			mVideoView.setVideoURI(videoUri);
+			mVideoView.setVideoURI(videoUri, headers);
 			mMediaController = new MediaController(this);
 			mMediaController.setAnchorView(mVideoView);
 			mMediaController.setMediaPlayer(mVideoView);

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
@@ -8,6 +8,10 @@ import android.content.ContentResolver;
 import android.content.Intent;
 import android.os.Build;
 import java.util.Iterator;
+import java.util.Properties;
+import java.util.Map;
+import java.util.HashMap;
+import java.io.Serializable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONException;
@@ -20,11 +24,14 @@ public class StreamingMedia extends CordovaPlugin {
 	public static final String ACTION_PLAY_AUDIO = "playAudio";
 	public static final String ACTION_PLAY_VIDEO = "playVideo";
 
+	public static final String INTENT_EXTRA_HEADERS = "headers";
+
 	private static final int ACTIVITY_CODE_PLAY_MEDIA = 7;
 
 	private CallbackContext callbackContext;
 
 	private static final String TAG = "StreamingMediaPlugin";
+
 
 	@Override
 	public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -76,11 +83,26 @@ public class StreamingMedia extends CordovaPlugin {
 								extras.putBoolean(optKey, (Boolean)options.get(optKey));
 								Log.v(TAG, "Added option: " + optKey + " -> " + String.valueOf(options.get(optKey)));
 							}
-
 						} catch (JSONException e) {
 							Log.e(TAG, "JSONException while trying to read options. Skipping option.");
 						}
 					}
+
+					// Header options
+					try {
+						JSONObject headersJSON = options.getJSONObject("headers");
+						Map<String,String> headers = new HashMap<>();
+						Iterator<String> headersJSONIterator = headersJSON.keys();
+						while(headersJSONIterator.hasNext()) {
+							String key = headersJSONIterator.next();
+							headers.put(key, headersJSON.getString(key));
+						}
+						extras.putSerializable(INTENT_EXTRA_HEADERS, (Serializable) headers);
+						Log.v(TAG, "Added option: headers -> " + headersJSON.toString());
+					} catch(JSONException e) {
+						// Do nothing, headers aren't present
+					}
+
 					streamIntent.putExtras(extras);
 				}
 

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
@@ -21,6 +21,14 @@ import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.PluginResult;
 
 public class StreamingMedia extends CordovaPlugin {
+
+	public static final String CALLBACK_EVENT_TYPE_KEY = "eventType";
+	public static final String CALLBACK_EVENT_TYPE_VALUE_LIFECYCLE_ONPAUSE = "LIFECYCLE_ONPAUSE";
+	public static final String CALLBACK_EVENT_TYPE_VALUE_LIFECYCLE_ONRESUME = "LIFECYCLE_ONRESUME";
+	public static final String CALLBACK_EVENT_TYPE_VALUE_PLAY = "PLAY";
+	public static final String CALLBACK_EVENT_TYPE_VALUE_PAUSE = "PAUSE";
+	public static final String CALLBACK_EVENT_TYPE_VALUE_SEEK = "SEEK";
+
 	public static final String ACTION_PLAY_AUDIO = "playAudio";
 	public static final String ACTION_PLAY_VIDEO = "playVideo";
 
@@ -120,14 +128,20 @@ public class StreamingMedia extends CordovaPlugin {
 		super.onActivityResult(requestCode, resultCode, intent);
 		if (ACTIVITY_CODE_PLAY_MEDIA == requestCode) {
 			if (Activity.RESULT_OK == resultCode) {
-				this.callbackContext.success();
+				StreamingMedia.callbackContext.success();
 			} else if (Activity.RESULT_CANCELED == resultCode) {
 				String errMsg = "Error";
 				if (intent != null && intent.hasExtra("message")) {
 					errMsg = intent.getStringExtra("message");
 				}
-				this.callbackContext.error(errMsg);
+				StreamingMedia.callbackContext.error(errMsg);
 			}
 		}
+	}
+
+	public static void sendCallback(JSONObject callbackData) {
+		PluginResult result = new PluginResult(PluginResult.Status.OK, callbackData);
+		result.setKeepCallback(true);
+		StreamingMedia.callbackContext.sendPluginResult(result);
 	}
 }

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
@@ -28,14 +28,14 @@ public class StreamingMedia extends CordovaPlugin {
 
 	private static final int ACTIVITY_CODE_PLAY_MEDIA = 7;
 
-	private CallbackContext callbackContext;
+	static CallbackContext callbackContext;
 
 	private static final String TAG = "StreamingMediaPlugin";
 
 
 	@Override
 	public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-		this.callbackContext = callbackContext;
+		StreamingMedia.callbackContext = callbackContext;
 		JSONObject options = null;
 
 		try {

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
@@ -82,6 +82,9 @@ public class StreamingMedia extends CordovaPlugin {
 							} else if (options.get(optKey).getClass().equals(Boolean.class)) {
 								extras.putBoolean(optKey, (Boolean)options.get(optKey));
 								Log.v(TAG, "Added option: " + optKey + " -> " + String.valueOf(options.get(optKey)));
+							} else if (options.get(optKey).getClass().equals(Integer.class)) {
+								extras.putInt(optKey, (Integer)options.get(optKey));
+								Log.v(TAG, "Added option: " + optKey + " -> " + String.valueOf(options.get(optKey)));
 							}
 						} catch (JSONException e) {
 							Log.e(TAG, "JSONException while trying to read options. Skipping option.");

--- a/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
+++ b/src/android/com/hutchind/cordova/plugins/streamingmedia/StreamingMedia.java
@@ -1,14 +1,11 @@
 package com.hutchind.cordova.plugins.streamingmedia;
 
 import android.app.Activity;
-import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
-import android.content.ContentResolver;
 import android.content.Intent;
-import android.os.Build;
+
 import java.util.Iterator;
-import java.util.Properties;
 import java.util.Map;
 import java.util.HashMap;
 import java.io.Serializable;
@@ -31,6 +28,7 @@ public class StreamingMedia extends CordovaPlugin {
 
 	public static final String ACTION_PLAY_AUDIO = "playAudio";
 	public static final String ACTION_PLAY_VIDEO = "playVideo";
+	public static final String ACTION_STOP_VIDEO = "stopVideo";
 
 	public static final String INTENT_EXTRA_HEADERS = "headers";
 
@@ -56,7 +54,9 @@ public class StreamingMedia extends CordovaPlugin {
 			return playAudio(args.getString(0), options);
 		} else if (ACTION_PLAY_VIDEO.equals(action)) {
 			return playVideo(args.getString(0), options);
-		} else {
+		} else if (ACTION_STOP_VIDEO.equals(action)) {
+      		return stopVideo();
+    	} else {
 			callbackContext.error("streamingMedia." + action + " is not a supported method.");
 			return false;
 		}
@@ -67,6 +67,11 @@ public class StreamingMedia extends CordovaPlugin {
 	}
 	private boolean playVideo(String url, JSONObject options) {
 		return play(SimpleVideoStream.class, url, options);
+	}
+	private boolean stopVideo() {
+    	Intent intent = new Intent(SimpleVideoStream.BROADCAST_INTENT_ACTION_STOP);
+    	cordova.getActivity().sendBroadcast(intent);
+    	return true;
 	}
 
 	private boolean play(final Class activityClass, final String url, final JSONObject options) {

--- a/www/StreamingMedia.js
+++ b/www/StreamingMedia.js
@@ -2,29 +2,28 @@
 function StreamingMedia() {
 }
 
-StreamingMedia.prototype.playAudio = function (url, options) {
-	options = options || {};
+StreamingMedia.prototype.playAudio = function (url, options = {}) {
 	cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "playAudio", [url, options]);
 };
 
-StreamingMedia.prototype.pauseAudio = function (options) {
-    options = options || {};
+StreamingMedia.prototype.pauseAudio = function (options = {}) {
     cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "pauseAudio", [options]);
 };
 
-StreamingMedia.prototype.resumeAudio = function (options) {
-    options = options || {};
+StreamingMedia.prototype.resumeAudio = function (options = {}) {
     cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "resumeAudio", [options]);
 };
 
-StreamingMedia.prototype.stopAudio = function (options) {
-    options = options || {};
+StreamingMedia.prototype.stopAudio = function (options = {}) {
     cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "stopAudio", [options]);
 };
 
-StreamingMedia.prototype.playVideo = function (url, options) {
-	options = options || {};
+StreamingMedia.prototype.playVideo = function (url, options = {}) {
 	cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "playVideo", [url, options]);
+};
+
+StreamingMedia.prototype.stopVideo = function (options = {}) {
+	cordova.exec(options.successCallback || null, options.errorCallback || null, "StreamingMedia", "stopVideo", []);
 };
 
 

--- a/www/StreamingMediaEvent.ts
+++ b/www/StreamingMediaEvent.ts
@@ -1,0 +1,13 @@
+enum StreamingEventType {
+    PLAY,
+    PAUSE,
+    SEEK
+}
+
+interface StreamingMediaEvent {
+    eventType: StreamingEventType
+}
+
+interface SeekEvent extends StreamingMediaEvent {
+    msec: number
+}


### PR DESCRIPTION
This PR allows you to add a "headers" option to the options object when playing either audio or video 
```
  var options = {
    successCallback: function() {
      console.log("Video was closed without error.");
    },
    errorCallback: function(errMsg) {
      console.log("Error! " + errMsg);
    },
    orientation: 'landscape',
    shouldAutoClose: true,  // true(default)/false
    controls: true, // true(default)/false. Used to hide controls on fullscreen
    headers: {
      Authorization: `Basic ${btoa(username + ':' + password)}`
    }
  };
  window.plugins.streamingMedia.playVideo(videoUrl, options);
```
These headers will be sent in the HTTP request when obtaining the media file